### PR TITLE
Alias most often used modules, cut the names

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,8 +7,6 @@ env:
 
 settings:
   import/resolver:
-    alias:
-      - ['@oacore/texts/dashboard', './texts']
     node:
       paths: ['.']
       extensions: ['.js', '.jsx']

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,10 @@ env:
   browser: true
 
 settings:
+  import/ignore:
+    # Ignores blind export of everything from node_modules as well as it's done
+    # by default
+    - design/index.js$
   import/resolver:
     node:
       paths: ['.']

--- a/design/index.js
+++ b/design/index.js
@@ -1,3 +1,5 @@
+export * from '@oacore/design/lib'
+
 export AppBarToggle from './app-bar/toggle'
 export Avatar from './avatar'
 export Card from './card'

--- a/next.config.js
+++ b/next.config.js
@@ -101,6 +101,7 @@ const nextConfig = {
       '@oacore/texts/dashboard': path.join(__dirname, 'texts'),
       design: path.join(__dirname, 'design'),
       components: path.join(__dirname, 'components'),
+      texts: path.join(__dirname, 'texts'),
       utils: path.join(__dirname, 'utils'),
     })
 

--- a/next.config.js
+++ b/next.config.js
@@ -100,6 +100,8 @@ const nextConfig = {
     Object.assign(config.resolve.alias, {
       '@oacore/texts/dashboard': path.join(__dirname, 'texts'),
       design: path.join(__dirname, 'design'),
+      components: path.join(__dirname, 'components'),
+      utils: path.join(__dirname, 'utils'),
     })
 
     return config

--- a/package-lock.json
+++ b/package-lock.json
@@ -5706,12 +5706,6 @@
         }
       }
     },
-    "eslint-import-resolver-alias": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
-      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
-      "dev": true
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@oacore/prettier-config": "^1.0.3",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.1",
-    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.0",


### PR DESCRIPTION
The idea behind is to simplify writing for this particular project and simplify long workgflow:

```js
import { AppBar } from '@oacore/design'
import { navigation } from '@oacore/texts/dashboard'

import { AppBarToggle } from 'design'
```

to **short one**:

```js
import { AppBar, AppBarToggle } from 'design'
import { navigation } from 'texts'
```

---

On top of #44 