### PR TITLE
Use correct publication date data field

### DIFF
--- a/pages/data-providers/[data-provider-id]/deposit-dates.jsx
+++ b/pages/data-providers/[data-provider-id]/deposit-dates.jsx
@@ -42,7 +42,8 @@ const tableConfig = {
       id: 'publicationDate',
       display: 'Publication date',
       className: styles.depositDateColumn,
-      getter: v => dayjs(v.publicationDate),
+      getter: v =>
+        dayjs(v.repositoryPublicationDate || v.crossrefPublicationDate),
       render: v => v.format('DD/MM/YYYY'),
     },
     {


### PR DESCRIPTION
I display primarily repository's publication date and if it's empty, Crossref's one. @mcancellieri let me know if I have to change this logic, you know the data better.

I would be happy to display both fields but for this moment I may affect layout negatively. Let's do it when we fix the layout please.

---

@Joozty we merge the PR only when @mcancellieri approves changes.