### PR TITLE
Extend overview chart data to show 4 years period, make it relative to data

### DIFF
--- a/pages/data-providers/[data-provider-id]/overview.jsx
+++ b/pages/data-providers/[data-provider-id]/overview.jsx
@@ -162,12 +162,27 @@ const DashboardView = ({
   </main>
 )
 
+const filterChartData = (data, complianceLevel = 0.75) => {
+  const dataLimit = 365 * 4
+  const complianceLimit = 90
+
+  const leftLimit =
+    complianceLimit + Math.floor(dataLimit * complianceLevel) * -1
+  const rightLimit = leftLimit + dataLimit
+
+  return data.filter(
+    item =>
+      item.depositTimeLag >= leftLimit && item.depositTimeLag <= rightLimit
+  )
+}
+
 const Dashboard = ({ store, ...restProps }) => (
   <DashboardView
     metadataCount={store.statistics.metadataCount}
     fullTextCount={store.statistics.fullTextCount}
-    timeLagData={store.depositDates.timeLagData.filter(
-      item => item.depositTimeLag >= -45 && item.depositTimeLag <= 135
+    timeLagData={filterChartData(
+      store.depositDates.timeLagData,
+      store.depositDates.complianceLevel / 100
     )}
     isTimeLagDataLoading={store.depositDates.isRetrieveDepositDatesInProgress}
     complianceLevel={store.depositDates.complianceLevel}


### PR DESCRIPTION
Deposit time lag chart on Overview page moves compliance limit point (90 days) relatively to compliance level percentage.

For example, for a compliance level 80% first 80% of chart is green and last 20% are grey.

Also, the limit of filtered data for overview extended to 4 years.