### PR TITLE
Fix text cut in expanded rows

### DIFF
--- a/components/table/TableRowExpanded.jsx
+++ b/components/table/TableRowExpanded.jsx
@@ -15,6 +15,7 @@ const TableRowExpanded = ({
     id={`${id}-expanded`}
     className={classNames(
       tableClassNames.additionalRow,
+      tableClassNames.detailRow,
       expandedRow.className,
       {
         [tableClassNames.closed]: !isExpanded,

--- a/components/table/index.css
+++ b/components/table/index.css
@@ -30,3 +30,10 @@
 .main-row {
   border-bottom: 0;
 }
+
+.detail-row {
+  & > th,
+  & > td {
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
When title or author list is too long to fin in the screen width it goes out of the screen. The PR fixes this bug.

@Joozty I have to merge this now. Letting you know how I did this fix.