### PR TITLE
Force using production API if NODE_ENV is production

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,15 @@
 import { NetworkError } from './errors'
 
 const CORE_API = 'https://api.core.ac.uk/internal'
-const CORE_API_DEV = 'https://api.dev.core.ac.uk/internal'
+
+/**
+ * Forces using production API URL and ignore `dev` parameter
+ * in the function below.
+ */
+const CORE_API_DEV =
+  process.env.NODE_ENV !== 'production'
+    ? 'https://api.dev.core.ac.uk/internal'
+    : CORE_API
 
 const apiRequest = (
   url,

--- a/public/login.html
+++ b/public/login.html
@@ -71,7 +71,7 @@
 </style>
 
 
-<form action="https://api.dev.core.ac.uk/login_check" onsubmit="login.apply(this, arguments);" method="post">
+<form action="https://api.core.ac.uk/login_check" onsubmit="login.apply(this, arguments);" method="post">
   <h1>Login</h1>
   <div id="error-message" class="message"></div>
   <label for="email"><b>Email</b></label>
@@ -87,7 +87,7 @@
 
 <script>
   function login(e) {
-    e.target.action = 'https://api.dev.core.ac.uk/login_check?continue=' + encodeURIComponent(
+    e.target.action = 'https://api.core.ac.uk/login_check?continue=' + encodeURIComponent(
       window.location.origin
     );
   }


### PR DESCRIPTION
I needed to add this quick dirty fix up to API client to make it work project-wide.

The fix makes `apiRequest` function ignore `dev` parameter. @Joozty is working on better version of checking environments in #108.

Passing correct URL to login page is still a question. I had to replace 2 strings but we do not support login to dev API anymore. I am considering having 2 equal pages for different environments but I will definitely think about it more.