### PR TITLE
Fix link to REF 2021 opening in new tab

### DIFF
--- a/components/markdown.jsx
+++ b/components/markdown.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import ReactMarkdown from 'react-markdown/with-html'
+
+const MarkdownLink = ({ href, title, children }) => {
+  const props = {
+    href,
+    title,
+  }
+
+  const isExternal = new URL(href).origin !== window?.location.origin
+  if (isExternal) {
+    Object.assign(props, {
+      target: '_blank',
+      rel: 'noopener',
+    })
+  }
+
+  return <a {...props}>{children}</a>
+}
+
+const markdownConfig = {
+  escapeHtml: false,
+
+  renderers: {
+    link: MarkdownLink,
+    linkReference: MarkdownLink,
+  },
+}
+
+const Markdown = ({ children, tag, ...markdownProps }) => (
+  <ReactMarkdown {...markdownConfig} {...markdownProps} root={tag}>
+    {children}
+  </ReactMarkdown>
+)
+
+export default Markdown

--- a/pages/data-providers/[data-provider-id]/deposit-dates.jsx
+++ b/pages/data-providers/[data-provider-id]/deposit-dates.jsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from 'react'
-import Markdown from 'react-markdown'
 import dayjs from 'dayjs'
 
 import { withGlobalStore } from 'store'
+import Markdown from 'components/markdown'
 import Table from 'components/table'
 import TimeLagChart from 'components/time-lag-chart'
 import { Button, Card, Label } from 'design'

--- a/pages/data-providers/[data-provider-id]/plugins.jsx
+++ b/pages/data-providers/[data-provider-id]/plugins.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import Markdown from 'react-markdown'
 
 import pluginsClassNames from './plugins.css'
 
+import Markdown from 'components/markdown'
 import { Card, Button } from 'design'
 import { plugins } from 'texts'
 


### PR DESCRIPTION
1. From the marketing perspective it's better to open external links in new tabs so users do not leave the website.
2. If we do not do that and the user leaves browser's 'back' button returns to white screen because we do not track pop state event. There is #127 for that.