### PR TITLE
Bring development environment back!

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,29 +1,16 @@
 import { NetworkError } from './errors'
-
-const CORE_API = 'https://api.core.ac.uk/internal'
-
-/**
- * Forces using production API URL and ignore `dev` parameter
- * in the function below.
- */
-const CORE_API_DEV =
-  process.env.NODE_ENV !== 'production'
-    ? 'https://api.dev.core.ac.uk/internal'
-    : CORE_API
+import { API_URL } from '../config'
 
 const apiRequest = (
   url,
   method = 'GET',
   queryParams = {},
-  customHeaders = {},
-  dev = false
+  customHeaders = {}
 ) => {
   const controller = new AbortController()
   const { signal } = controller
 
-  const requestUrl = new URL(
-    /^\w+:\/\//.test(url) ? url : `${dev ? CORE_API_DEV : CORE_API}${url}`
-  )
+  const requestUrl = new URL(/^\w+:\/\//.test(url) ? url : `${API_URL}${url}`)
   const requestHeaders = {
     Accept: 'application/json',
     ...customHeaders,

--- a/config.js
+++ b/config.js
@@ -1,0 +1,13 @@
+export const API_URL =
+  process.env.NODE_ENV === 'production'
+    ? 'https://api.core.ac.uk/internal'
+    : 'https://api.dev.core.ac.uk/internal'
+
+const ORIGIN = encodeURIComponent(
+  typeof window == 'object' ? window.location.origin : ''
+)
+
+export const LOGIN_URL =
+  process.env.NODE_ENV === 'production'
+    ? '/login.html'
+    : new URL(`/test/login?continue=${ORIGIN}`, API_URL).toString()

--- a/pages/_app/index.jsx
+++ b/pages/_app/index.jsx
@@ -3,6 +3,7 @@ import NextApp from 'next/app'
 import { withRouter } from 'next/router'
 import { autorun } from 'mobx'
 
+import { LOGIN_URL } from '../../config'
 import Route from './route'
 
 import '@oacore/design/lib/index.css'
@@ -41,7 +42,7 @@ class App extends NextApp {
   }
 
   redirectToLogin = () => {
-    window.location.replace('/login.html')
+    window.location.replace(LOGIN_URL)
   }
 
   reflectStoreToRoute() {


### PR DESCRIPTION
Creates `config.js` for global environment-related configurations.

Moves API endpoint definition to `config.js`.

Changes apiRequest:
- removes `dev` parameter
- uses global API_URL

Makes redirect to login conditional based on environment.