### PR TITLE
Disable Content-Security-Policy in development environment

### DIFF
--- a/pages/_app/index.jsx
+++ b/pages/_app/index.jsx
@@ -37,12 +37,12 @@ class App extends NextApp {
       pageProps = (await Component.getInitialProps({ ...ctx })) || {}
 
     // add the header only on server-side
-    if (ctx?.res != null && process.env.NODE_ENV === 'production') {
+    if (ctx?.res != null) {
       ctx.res.setHeader(
         'Content-Security-Policy',
         [
           // consider everything from these two domains as a safe
-          "default-src 'self' *.core.ac.uk",
+          "default-src 'self' *.core.ac.uk core.ac.uk",
           // in development there are attached inline scripts
           // (probably from hot reload or some Next.JS magic)
           `script-src 'self' *.google-analytics.com ${
@@ -53,8 +53,8 @@ class App extends NextApp {
           "style-src 'self' 'unsafe-inline'",
           // google analytics may transport info via image
           // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
-          "img-src 'self' data: *.core.ac.uk *.google-analytics.com",
-          "connect-src 'self' *.core.ac.uk sentry.io *.google-analytics.com",
+          "img-src 'self' *.core.ac.uk core.ac.uk data: 'self' *.google-analytics.com",
+          "connect-src 'self' *.core.ac.uk core.ac.uk sentry.io *.google-analytics.com",
         ].join(';')
       )
     }

--- a/pages/_app/index.jsx
+++ b/pages/_app/index.jsx
@@ -37,7 +37,7 @@ class App extends NextApp {
       pageProps = (await Component.getInitialProps({ ...ctx })) || {}
 
     // add the header only on server-side
-    if (ctx?.res != null) {
+    if (ctx?.res != null && process.env.NODE_ENV === 'production') {
       ctx.res.setHeader(
         'Content-Security-Policy',
         [


### PR DESCRIPTION
Images are not shown because of Content-Security-Policy, at least on localhost. I propose to disable it in development environment.

I may be wrong but I cannot display an image from CORE static website neither on localhost nor on [staging](https://dashboard-git-installation-instructions.oacore.now.sh/data-providers/27/plugins/discovery).

It affects #87 