### PR TITLE
Rename deposit dates navigation item

### DIFF
--- a/texts/navigation.yml
+++ b/texts/navigation.yml
@@ -4,7 +4,7 @@ items:
   index: Overview
   data: Data
   content: Content
-  deposit-dates: Deposit dates
+  deposit-dates: Deposit compliance
   plugins: Plugins
   statistics: Statistics
   settings: Settings


### PR DESCRIPTION
I found it's quite hard to rename id's and change the URL to reflect this change. We will have it deposit-dates everywhere.