### PR TITLE
Refactor application model

### DIFF
--- a/store/data-provider.js
+++ b/store/data-provider.js
@@ -1,0 +1,18 @@
+import Resource from './resource'
+
+class DataProvider extends Resource {
+  static defaultValues = {
+    name: null,
+    email: null,
+    statistics: {},
+    plugins: {},
+  }
+
+  init(...args) {
+    super.init(...args)
+    if (this.options.prefetch) return this.retrieve(['statistics', 'plugins'])
+    return Promise.resolve()
+  }
+}
+
+export default DataProvider

--- a/store/resource.js
+++ b/store/resource.js
@@ -31,7 +31,6 @@ class Resource {
     Object.assign(this, object)
   }
 
-  @action
   retrieve(...scopes) {
     const { request } = this.options
     if (this.id == null) {
@@ -51,7 +50,7 @@ class Resource {
       }
 
       return request(this[scopeUrl]).then((data) => {
-        this[scope] = data
+        this.extend({ [scope]: data })
         return data
       })
     })

--- a/store/resource.js
+++ b/store/resource.js
@@ -1,0 +1,63 @@
+import { action, extendObservable } from 'mobx'
+
+import apiRequest from 'api'
+
+class Resource {
+  static defaultOptions = {
+    request: (...args) => apiRequest(args).then(({ data }) => data),
+    prefetch: false,
+  }
+
+  static defaultValues = {}
+
+  constructor(init, options) {
+    this.options = { ...this.constructor.defaultOptions, ...options }
+    extendObservable(this, this.constructor.defaultValues)
+
+    this.init(init)
+  }
+
+  @action
+  init(init) {
+    const data = typeof init == 'string' ? { url: init } : init
+    Object.assign(this, data)
+
+    const { prefetch } = this.options
+    if (typeof init == 'string' && prefetch) this.retrieve()
+  }
+
+  @action
+  extend(object) {
+    Object.assign(this, object)
+  }
+
+  @action
+  retrieve(...scopes) {
+    const { request } = this.options
+    if (this.id == null) {
+      return request(this.url).then((data) => {
+        this.extend(data)
+        return this.retrieve(...scopes)
+      })
+    }
+
+    const requests = scopes.map((scope) => {
+      const scopeUrl = `${scope}Url`
+
+      if (this[scopeUrl] == null) {
+        throw new Error(
+          `Trying to retrieve non-existing nested property '${scope}' via '${scopeUrl}'`
+        )
+      }
+
+      return request(this[scopeUrl]).then((data) => {
+        this[scope] = data
+        return data
+      })
+    })
+
+    return Promise.allSettled(requests)
+  }
+}
+
+export default Resource

--- a/store/user/base.js
+++ b/store/user/base.js
@@ -1,0 +1,28 @@
+import { action } from 'mobx'
+
+import Resource from '../resource'
+
+const anonymousUser = {
+  name: 'Anonymous',
+  email: null,
+}
+
+class User extends Resource {
+  static defaultValues = anonymousUser
+
+  @action
+  async init({ id } = {}) {
+    try {
+      const url = id == null ? '/user' : `/users/${id}`
+      super.init(url)
+    } catch (unauthorisedError) {
+      throw new Error('User is unauthorised. Using Anonymous')
+    }
+  }
+
+  get anonymous() {
+    return this.id == null
+  }
+}
+
+export default User

--- a/store/user/dashboard.js
+++ b/store/user/dashboard.js
@@ -1,0 +1,20 @@
+import User from './base'
+
+class DashboardUser extends User {
+  static defaultValues = {
+    ...User.defaultValues,
+    dataProviders: [],
+  }
+
+  owns(dataProviderId) {
+    return this.dataProviders.some(({ id }) => dataProviderId === id)
+  }
+
+  searchDataProviders(searchTerm) {
+    return this.dataProviders.filter(
+      (e) => e.name.toLowerCase().search(searchTerm.toLowerCase()) !== -1
+    )
+  }
+}
+
+export default DashboardUser

--- a/store/user/index.js
+++ b/store/user/index.js
@@ -1,0 +1,5 @@
+import BaseUser from './base'
+import DashboardUser from './dashboard'
+
+export default DashboardUser
+export { BaseUser, DashboardUser }


### PR DESCRIPTION
The plan is really ambitious:

1. Move the statistics, plugins and all related to a data provider into the DataProvider store
   * Fixes stale numeric values after switching the data provider
2. Make `init()` methods more smart to implicitly handle most of of stuff
3. Allow anonymous users, improve user management
4. Remove UI values from the model
5. Create a central application management model

## Status

1. 🚧 Done with issues
2. 🚧 Done with issues
3. ❌ Needs proper error handling
4. ❌ Next 9.3 deprecates `getInitialProps`
5. ❌ Issues

I am in order to drop this. @Joozty if you have some time, feel free to provide a feedback