### PR TITLE
Disable logout container word wrapping

### DIFF
--- a/components/application/logout.css
+++ b/components/application/logout.css
@@ -1,9 +1,14 @@
-@custom-media --screen-until-desktop (max-width: 727px);
+@custom-media --screen-until-desktop (max-width: 1199px);
+
+.container {
+  word-wrap: nowrap;
+}
 
 .name {
   &::after {
     content: ' | ';
   }
+
   @media (--screen-until-desktop) {
     display: none;
   }


### PR DESCRIPTION
Fixes double lined application bar.

![The bug screenshot](https://user-images.githubusercontent.com/8440244/77060528-6158f780-69e1-11ea-979c-1cbca7fd0dbe.png)