### PR TITLE
Read configuration from environment

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,5 +1,6 @@
 import { NetworkError } from './errors'
-import { API_URL } from '../config'
+
+const { API_URL } = process.env
 
 const prepareUrl = (pathname, base = API_URL) => {
   const url = /^\w+:\/\//.test(pathname) ? pathname : `${base}${pathname}`

--- a/components/application/logout.jsx
+++ b/components/application/logout.jsx
@@ -1,28 +1,30 @@
 import React from 'react'
 import { AppBar } from '@oacore/design'
 
-import { API_URL } from '../../config'
 import styles from './logout.css'
 
 import { withGlobalStore } from 'store'
 
-const LOGOUT_URL = `${API_URL.replace(
-  '/internal',
-  ''
-)}/logout?continue=${encodeURIComponent(
-  typeof window !== 'undefined'
-    ? `${window.location.origin}/?reason=logout`
-    : ''
-)}`
+const { IDP_URL } = process.env
+
+const getLogoutUrl = pathname => {
+  const url = new URL('./logout', IDP_URL)
+  if (pathname != null) url.searchParams.set('continue', pathname)
+  return url
+}
 
 const Logout = ({ store }) => {
   if (!store.user) return null
   const name = store.user.email
+  const redirectUrl =
+    typeof window != 'undefined'
+      ? `${window.location.origin}?reson=logout`
+      : null
 
   return (
     <AppBar.Item className={styles.container}>
       <span className={styles.name}>{name}</span>{' '}
-      <a href={LOGOUT_URL}>Logout</a>
+      <a href={getLogoutUrl(redirectUrl)}>Logout</a>
     </AppBar.Item>
   )
 }

--- a/config.js
+++ b/config.js
@@ -1,18 +1,30 @@
-export const API_URL =
-  process.env.NODE_ENV === 'production'
-    ? 'https://api.core.ac.uk/internal'
-    : 'https://api.dev.core.ac.uk/internal'
+const NODE_ENV = process.env.NODE_ENV || 'development'
 
-export const getLoginPage = (path = window.location.origin) => {
-  if (process.env.NODE_ENV === 'production') {
-    return new URL(
-      `/login.html?continue=${encodeURIComponent(path)}`,
-      window.location.origin
-    ).toString()
-  }
-
-  return new URL(
-    `/test/login?continue=${encodeURIComponent(path)}`,
-    API_URL
-  ).toString()
+const local = {
+  API_URL: 'http://127.0.0.1:8000/internal',
+  IDP_URL: 'http://127.0.0.1:8000',
 }
+
+const development = {
+  API_URL: 'https://api.dev.core.ac.uk/internal',
+  IDP_URL: 'https://api.dev.core.ac.uk',
+}
+
+const production = {
+  API_URL: 'https://api.core.ac.uk/internal',
+  IDP_URL: 'https://api.core.ac.uk',
+}
+
+const validate = config =>
+  ['API_URL', 'IDP_URL'].forEach(param => {
+    if (config[param] == null) throw new Error(`${param} is not configured.`)
+  })
+
+const env = { local, development, production }
+const config = {
+  ...env.production,
+  ...env[NODE_ENV],
+}
+
+validate(config)
+module.exports = config

--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,11 @@ const withSourceMaps = require('@zeit/next-source-maps')
 
 const camelCaseLoader = path.join(__dirname, 'webpack/camelcase-loader.js')
 
+const envConfig = require('./config')
+
 const nextConfig = {
+  env: envConfig,
+
   webpack(config, options) {
     const { dev, isServer } = options
 

--- a/now.json
+++ b/now.json
@@ -1,7 +1,5 @@
 {
   "version": 2,
-  "name": "dashboard",
-  "builds": [{ "src": "next.config.js", "use": "@now/next" }],
   "build": {
     "env": {
       "NPM_TOKEN": "@npm_token",

--- a/now.json
+++ b/now.json
@@ -4,7 +4,8 @@
   "builds": [{ "src": "next.config.js", "use": "@now/next" }],
   "build": {
     "env": {
-      "NPM_TOKEN": "@npm_token"
+      "NPM_TOKEN": "@npm_token",
+      "NODE_ENV": "development"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "scripts": {
     "dev": "next dev",
+    "dev-api": "NODE_ENV=local next dev",
     "build:icons": "svgstore public/icons/* | svgo -i - -o public/icons.svg --disable=removeUselessDefs,cleanupIDs",
     "prebuild": "run-p build:icons",
     "build": "next build",

--- a/public/login.js
+++ b/public/login.js
@@ -35,7 +35,8 @@ function login(event) {
   window.dispatchEvent(new Event('login-processing'))
   const formData = new FormData(event.target)
   const data = new URLSearchParams(formData)
-  fetch(`${identityProviderUrl}login_check`, {
+  const url = new URL('login_check', identityProviderUrl)
+  fetch(url, {
     method: 'POST',
     body: data,
     credentials: 'include',

--- a/store/deposit-dates.js
+++ b/store/deposit-dates.js
@@ -2,9 +2,10 @@ import { action, computed, observable } from 'mobx'
 
 import { Pages } from './helpers/pages'
 
-import { API_URL } from 'config'
 import apiRequest from 'api'
 import { NotFoundError } from 'api/errors'
+
+const { API_URL } = process.env
 
 class DepositDates {
   @observable isExportDisabled = false


### PR DESCRIPTION
Introduces 3 configuration environments:
* production
* development
* local

where `local` environment is a `development` one targeted to local version of the API.

Adds a `dev-api` command to test API locally during development. @valerapro this may be useful for you.

Adds an identity provider URL as `IDP_URL`.

Replace `getLoginPage` with pure constant called `LOGIN_URL` and moves it to the central configuration file. The function logic moved to App component.

Moves `LOGOUT_URL` to the configuration file leaving `continue` parameter passing in the Logout component.

---

Importing configuration is **deprecated**. All configuration variables are passed via `process.env`.

---

Also, marks Now as a development area.