### PR TITLE
Fix postInstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx .",
     "lint:css": "stylelint --ignore-path .gitignore '**/*.css'",
     "lint": "run-p lint:*",
-    "postinstall": "cp -r \"$(npm explore @oacore/design -- pwd)/lib/assets\" ./public/design"
+    "postinstall": "rm -rf ./public/design/ && cp -r \"$(npm explore @oacore/design -- pwd)/lib/assets\" ./public/design"
   }
 }


### PR DESCRIPTION
Previously cp command created assets subdirectory in ./public/design if design folder existed. So before copying the folder is firstly removed. We could have used -T flag but it's not available on MacOS therefore this approach.

See more:
https://stackoverflow.com/questions/23698183/how-to-force-cp-to-overwrite-directory-instead-of-creating-another-one-inside