### PR TITLE
Redirect users to the legacy Dashboard if access forbidden

### DIFF
--- a/pages/_app/index.jsx
+++ b/pages/_app/index.jsx
@@ -16,6 +16,7 @@ import Application from 'components/application'
 import { Sentry } from 'utils/sentry'
 
 const { IDP_URL } = process.env
+const FORBIDDEN_REDIRECT_URL = 'https://dashboard.core.ac.uk'
 
 process.on('unhandledRejection', err => {
   Sentry.captureException(err)
@@ -99,6 +100,8 @@ class App extends NextApp {
   handlePostMessage = async event => {
     if (event.data === 'login-processing' && !this.state.isAuthorized)
       await this.fetchUser()
+    else if (event.data === 'login-fallback')
+      window.location.replace(FORBIDDEN_REDIRECT_URL)
   }
 
   reflectStoreToRoute = () => {

--- a/public/login.js
+++ b/public/login.js
@@ -1,3 +1,22 @@
+/* eslint-disable max-classes-per-file */
+
+class UnauthorisedError extends Error {}
+class ForbiddenError extends Error {}
+
+function performLoginRequest(url, data) {
+  return fetch(url, {
+    method: 'POST',
+    body: data,
+    credentials: 'include',
+  }).then(response => {
+    if (response.status === 401)
+      throw new UnauthorisedError('Wrong credentials')
+    if (response.status === 402 || response.status === 403)
+      throw new ForbiddenError('User does not have access to this version')
+    return response
+  })
+}
+
 function addLoadingAnimation() {
   const form = document.getElementById('login-form')
   form.classList.add('loading')
@@ -31,23 +50,33 @@ function login(event) {
   const urlParams = new URLSearchParams(window.location.search)
   const identityProviderUrl =
     urlParams.get('identity_provider_url') || 'https://api.core.ac.uk/'
+  const fallbackIDP =
+    urlParams.get('fallback_idp') || 'https://dashboard.core.ac.uk/'
 
   window.dispatchEvent(new Event('login-processing'))
   const formData = new FormData(event.target)
   const data = new URLSearchParams(formData)
-  const url = new URL('login_check', identityProviderUrl)
-  fetch(url, {
-    method: 'POST',
-    body: data,
-    credentials: 'include',
-  })
-    .then(r => {
-      if (r.status === 401) showWrongCredentialsMessage()
-    })
-    .finally(() => {
+  const loginUrl = new URL('login_check', identityProviderUrl)
+  performLoginRequest(loginUrl, data)
+    .then(
+      () => 'login-processing',
+      error => {
+        if (error instanceof ForbiddenError) {
+          const fallbackUrl = new URL('login_check', fallbackIDP)
+          return performLoginRequest(fallbackUrl, data).then(
+            () => 'login-fallback',
+            () => 'login-fallback'
+          )
+        }
+
+        if (error instanceof UnauthorisedError) showWrongCredentialsMessage()
+        return 'login-processing'
+      }
+    )
+    .then(message => {
       if (window.location !== window.parent.location) {
         // The page is in an iframe
-        window.parent.postMessage('login-processing', window.location.origin)
+        window.parent.postMessage(message, window.location.origin)
       } else window.location = '/'
     })
 


### PR DESCRIPTION
@oacore/dashboard it's poorly tested faking a login error. It **requires setting up CORS** for the `dashboard.core.ac.uk/login_check` endpoint in the same way we have on API to work properly.

## Algorithm

At this moment the feature works in the following way:

1. If the `api.core.ac.uk/user` returns 2xx, logged it
2. If the `api.core.ac.uk/login_check` returns 2xx, logged in
3. Else send the same data to `dashboard.core.ac.uk/login_check`
4. Without checking any response, does not matter was it successful or was there a CORS error, redirect the user to `dashboard.core.ac.uk`

## Last step explained

1. If the legacy dashboard logged user in using credentials we sent, the user after visiting the home page will be redirected to the internal area
2. If the user is not logged in because of CORS they are obliged to log in again

## Assumptions

I assume that the API returns 402/403 **only** when the user passed valid credentials but is not logged in only because of the billing plan. This means the user can easily login with the same credentials to the legacy Dashboard so I just redirect the same request to another endpoint. 

Also, I assume that the user is not logged into the API. If they are, refreshing the page or visiting the new Dashboard in the new tab will provide access to the new Dashboard.

@valerapro please confirm this works as I described.

