### PR TITLE
Fix table sorting

### DIFF
--- a/components/table/index.jsx
+++ b/components/table/index.jsx
@@ -76,15 +76,17 @@ class InfiniteTable extends React.PureComponent {
 
     // TODO: Maybe there is a better way for distinguish Column children
     const columns = childrenArray.filter(
-      item =>
-        item.type === Column ||
-        Object.prototype.isPrototypeOf.call(Column, item.type)
+      child =>
+        child.type === Column ||
+        Object.prototype.isPrototypeOf.call(Column, child.type)
     )
-    const columnOrder = columns.reduce((acc, curr) => {
-      acc[curr.props.id] =
-        curr.props.order !== undefined ? curr.props.order : null
-      return acc
-    }, {})
+
+    const columnOrder = Object.fromEntries(
+      columns.map(column => {
+        const { id, order = null } = column.props
+        return [id, order]
+      })
+    )
 
     return {
       sidebar: childrenArray.find(item => item.type === Sidebar),
@@ -105,19 +107,16 @@ class InfiniteTable extends React.PureComponent {
 
   toggleOrder = id => {
     const { columnOrder } = this.state
-    if (columnOrder[id] === undefined) return
+    if (columnOrder[id] == null) return
 
     this.setState(
       {
-        columnOrder: Object.entries(columnOrder).reduce(
-          (acc, [currId, currOrder]) => {
-            if (currId === id) acc[currId] = getNextOrder(currOrder)
-            else if (currOrder === null) acc[currId] = null
-            else acc[currId] = ''
-
-            return acc
-          },
-          {}
+        columnOrder: Object.fromEntries(
+          Object.entries(columnOrder).map(([currId, currOrder]) => {
+            if (currId === id) return [currId, getNextOrder(currOrder)]
+            if (currOrder == null) return [currId, null]
+            return [currId, 'any']
+          })
         ),
       },
       () => this.fetchData({ force: true })

--- a/pages/data-providers/[data-provider-id]/content.jsx
+++ b/pages/data-providers/[data-provider-id]/content.jsx
@@ -92,6 +92,7 @@ const Data = ({ store, ...restProps }) => (
       <Table.Column
         id="oai"
         display="OAI"
+        order="any"
         getter={v => {
           const { oai } = v.identifier
           return oai.split(':').pop()
@@ -102,6 +103,7 @@ const Data = ({ store, ...restProps }) => (
       <Table.Column
         id="authors"
         display="Authors"
+        order="any"
         className={styles.authorsColumn}
         getter={v => v.author.map(a => a.name).join(' ')}
       />

--- a/pages/data-providers/[data-provider-id]/deposit-dates.jsx
+++ b/pages/data-providers/[data-provider-id]/deposit-dates.jsx
@@ -109,23 +109,27 @@ const DepositDates = ({
         <Table.Column
           id="oai"
           display="OAI"
+          order="any"
           getter={v => v.oai.split(':').pop()}
           className={styles.oaiColumn}
         />
         <Table.Column
           id="title"
           display="Title"
+          order="any"
           className={styles.titleColumn}
         />
         <Table.Column
           id="authors"
           display="Authors"
+          order="any"
           className={styles.authorsColumn}
           getter={v => v.authors && v.authors.map(a => a.name).join(' ')}
         />
         <Table.Column
           id="publicationDate"
           display="Publication date"
+          order="any"
           className={styles.depositDateColumn}
           getter={v => dayjs(v.publicationDate).format('DD/MM/YYYY')}
         />

--- a/store/helpers/order.js
+++ b/store/helpers/order.js
@@ -1,7 +1,8 @@
 const getOrder = columnOrder =>
   Object.entries(columnOrder)
-    .filter(i => i[1])
-    .map(([k, v]) => `${k}:${v}`)
+    .map(([property, direction]) => [property, (direction || '').toLowerCase()])
+    .filter(([, direction]) => direction === 'asc' || direction === 'desc')
+    .map(([property, direction]) => `${property}:${direction}}`)
     .join(';')
 
 export default getOrder


### PR DESCRIPTION
1. Obfuscates invalid sorting directions, converts it to a string in lower case, accepts only 'asc' and 'desc' as correct values.

2. In `Table` component treats `null` as well as `undefined`. Allow to pass 'any' as sorting direction.

3. Allows sorting by OAI and author Also, allows sorting deposit dates by title and publication date.