### PR TITLE
Measure speed of endpoints

### DIFF
--- a/pages/_app/index.jsx
+++ b/pages/_app/index.jsx
@@ -10,7 +10,7 @@ import Route from './route'
 import styles from './index.css'
 
 import { UnauthorizedError } from 'api/errors'
-import logPageView from 'utils/analytics'
+import { logPageView } from 'utils/analytics'
 import { initStore, GlobalProvider } from 'store'
 import Application from 'components/application'
 import { Sentry } from 'utils/sentry'

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -4,14 +4,23 @@ const isProduction = process.env.NODE_ENV === 'production'
 let isGAInitialized = false
 
 if (isProduction && process.env.GA_TRACKING_CODE) {
-  ReactGA.initialize(process.env.GA_TRACKING_CODE)
+  ReactGA.initialize(process.env.GA_TRACKING_CODE, {
+    siteSpeedSampleRate: 100,
+  })
   isGAInitialized = true
 }
 
-const logPageView = (url = null) => {
+export const logPageView = (url = null) => {
   if (!isGAInitialized) return
   ReactGA.set({ page: url || window.location.pathname })
   ReactGA.pageview(url || window.location.pathname)
 }
 
-export default logPageView
+export const logTiming = options => {
+  ReactGA.timing(options)
+}
+
+export default {
+  logPageView,
+  logTiming,
+}


### PR DESCRIPTION
Maybe it would be better to have this measure on the backend but this is also good. This can help us understand the bottlenecks and proactively fix them instead of waiting for the user's feedback.


You can find measurement results [here](https://analytics.google.com/analytics/web/#/report/content-site-speed-user-timings/a66779096w222136427p211062458/_u.date00=20200326&_u.date01=20200327&userTimingsExplorer-segmentExplorer.segmentId=analytics.userTimingVariable&userTimingsExplorer-table.plotKeys=%5B%5D/).