### PR TITLE
Remove @observer from the global App component

### DIFF
--- a/components/application/index.jsx
+++ b/components/application/index.jsx
@@ -1,12 +1,11 @@
 import React from 'react'
 
 import { Container, AppBar, SideBar, Main } from '../layout'
-import LoadingBar from '../loading-bar'
+import LoadingBar from './loading-bar'
 import RepositorySelect from './repository-select'
 import ActivitySelect from './activity-select'
 import Head from './head'
 import Logout from './logout'
-import styles from './styles.css'
 
 import activities from 'store/activities'
 
@@ -15,13 +14,12 @@ const Application = ({
   dataProvider,
   activity,
   isAuthenticated = false,
-  isLoading = false,
   ...restProps
 }) => (
   <>
     <Head />
     <Container {...restProps}>
-      {isLoading && <LoadingBar className={styles.loadingBar} />}
+      <LoadingBar />
       <AppBar variant={isAuthenticated ? 'internal' : 'public'}>
         {isAuthenticated ? (
           <>

--- a/components/application/loading-bar.jsx
+++ b/components/application/loading-bar.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { observer } from 'mobx-react'
+
+import styles from './styles.css'
+
+import { withGlobalStore } from 'store'
+import LoadingBar from 'components/loading-bar'
+
+const LoadingBarController = ({ store }) =>
+  store.isLoading ? <LoadingBar className={styles.loadingBar} /> : null
+
+export default withGlobalStore(observer(LoadingBarController))

--- a/pages/_app/index.jsx
+++ b/pages/_app/index.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import NextApp from 'next/app'
 import { withRouter } from 'next/router'
 import { autorun } from 'mobx'
-import { observer } from 'mobx-react'
 
 import '@oacore/design/lib/index.css'
 
@@ -26,7 +25,6 @@ process.on('uncaughtException', err => {
   Sentry.captureException(err)
 })
 
-@observer
 class App extends NextApp {
   state = {
     isAuthorized: false,
@@ -265,7 +263,6 @@ class App extends NextApp {
           dataProvider={store.dataProvider}
           activity={store.activity.id}
           onClick={this.handleNavigation}
-          isLoading={store.isLoading}
           isAuthenticated
         >
           <Component {...pageProps} />


### PR DESCRIPTION
Fixes (should fix) the bug with infinite redirect loop in 'back' button press.

Creates an observer LoadingBar component inside the Application component.