### PR TITLE
Add password reset forms

### DIFF
--- a/components/forms/change-password/index.jsx
+++ b/components/forms/change-password/index.jsx
@@ -4,14 +4,13 @@ import styles from './styles.module.css'
 
 import { IframeForm } from 'components/forms'
 import { Card } from 'design'
-import { withGlobalStore } from 'store'
 
 const { IDP_URL } = process.env
 
-const ChangePassword = ({ className, store, tag }) => {
-  const email = store.user?.email
+const ChangePassword = ({ className, email, token, tag }) => {
   const searchParams = {
     ...(email != null ? { email } : {}),
+    ...(token != null ? { token } : {}),
     identity_provider_url: IDP_URL,
   }
 
@@ -29,4 +28,4 @@ const ChangePassword = ({ className, store, tag }) => {
   )
 }
 
-export default withGlobalStore(ChangePassword)
+export default ChangePassword

--- a/pages/data-providers/[data-provider-id]/settings.jsx
+++ b/pages/data-providers/[data-provider-id]/settings.jsx
@@ -86,7 +86,11 @@ const Settings = ({ store, className, ...restProps }) => {
         </FormShell>
       </Card>
 
-      <ChangePassword className={styles.section} tag="section" />
+      <ChangePassword
+        className={styles.section}
+        email={store.user.email}
+        tag="section"
+      />
     </main>
   )
 }

--- a/pages/reset/[token].jsx
+++ b/pages/reset/[token].jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { withRouter } from 'next/router'
+
+import styles from './styles.module.css'
+
+import { ChangePassword } from 'components/forms'
+
+const CreatePassword = ({ router }) => (
+  <ChangePassword
+    tag="div"
+    className={styles.resetContainer}
+    email={router.query.email}
+    token={router.query.token}
+  />
+)
+
+export default withRouter(CreatePassword)

--- a/pages/reset/index.jsx
+++ b/pages/reset/index.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+import { classNames } from '@oacore/design/lib/utils'
+
+import styles from './styles.module.css'
+
+import { Card, TextField, Button } from 'design'
+import { withGlobalStore } from 'store'
+
+const ResetPassword = ({ className, store, ...restProps }) => {
+  const [message, setMessage] = useState(null)
+
+  // TODO: Better texts and move it to @oacore/texts
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    try {
+      const formData = new FormData(event.target)
+      const data = {
+        email: formData.get('email'),
+      }
+      await store.user.requestResetToken(data)
+      setMessage('Please check your mailbox with the following instructions.')
+    } catch (error) {
+      setMessage("Something wen't wrong. Please try it again!")
+    }
+    return false
+  }
+
+  return (
+    <Card
+      className={classNames.use(styles.resetContainer, className)}
+      {...restProps}
+    >
+      <form onSubmit={handleSubmit}>
+        <h2>Reset password</h2>
+        <TextField id="email" label="Email" name="email" tag="p" required />
+        <Button variant="contained">Continue</Button>
+        {message && <p>{message}</p>}
+      </form>
+    </Card>
+  )
+}
+
+export default withGlobalStore(ResetPassword)

--- a/pages/reset/styles.module.css
+++ b/pages/reset/styles.module.css
@@ -1,9 +1,8 @@
-.login-iframe-container {
+.reset-container {
   position: absolute;
   top: 50%;
   left: 50%;
   width: 100%;
   max-width: 25rem;
-  min-height: 16rem;
   transform: translate(-50%, -50%);
 }

--- a/public/secure/login.css
+++ b/public/secure/login.css
@@ -83,3 +83,7 @@
 .loading > .blur-background ~ * {
   filter: blur(1px);
 }
+
+.forgotten-password {
+  float: right;
+}

--- a/public/secure/login.html
+++ b/public/secure/login.html
@@ -37,6 +37,7 @@
   <input type="hidden" name="remember_me" value="on">
 
   <button class="button contained" type="submit">Login</button>
+  <a class="forgotten-password" href="/reset" target="_top">Forgotten password?</a>
 </form>
 
 <script src="/secure/login.js" ></script>

--- a/public/secure/reset.js
+++ b/public/secure/reset.js
@@ -7,6 +7,7 @@ const email = document.getElementById('email')
 const token = document.getElementById('token')
 const form = document.getElementById('password-form')
 const requiredInputs = form.querySelectorAll('[required]')
+const password = document.getElementById('password')
 const newPassword = document.getElementById('newPassword')
 const newPasswordAgain = document.getElementById('newPasswordAgain')
 
@@ -23,7 +24,7 @@ function performApiRequest(url, data) {
     //     Currently API sends only 400 `{"message": "error"}`
     if (response.status !== 200) {
       throw new WrongInputError(
-        'Looks like you typed in wrong password. Please try it again!'
+        'Password reset error. Please request reset password again!'
       )
     }
     return response
@@ -32,7 +33,8 @@ function performApiRequest(url, data) {
 
 function showSuccessMessage() {
   const messageEl = document.getElementById('message')
-  messageEl.innerHTML = 'Password changed successfully'
+  messageEl.innerHTML =
+    'Password changed successfully. You can <a href="/login" target="_top">log in</a> now.'
   messageEl.classList.remove('message-error')
 }
 
@@ -65,7 +67,7 @@ function changePassword(event) {
     email: formData.get('email'),
     password: formData.get('password'),
     newPassword: formData.get('newPassword'),
-    token: formData.get('token'),
+    confirmationToken: formData.get('token'),
   }
 
   // remove empty params
@@ -100,9 +102,15 @@ window.addEventListener('DOMContentLoaded', () => {
     email.value = urlParams.get('email')
     email.setAttribute('type', 'hidden')
     email.parentElement.classList.add('hidden')
+  }
+
+  if (urlParams.has('token')) {
     token.value = urlParams.get('token')
     token.setAttribute('type', 'hidden')
     token.parentElement.classList.add('hidden')
+    password.removeAttribute('required')
+    password.setAttribute('type', 'hidden')
+    password.parentElement.classList.add('hidden')
   }
 
   requiredInputs.forEach((el) => {

--- a/store/user.js
+++ b/store/user.js
@@ -28,6 +28,14 @@ class User extends Store {
     extendObservable(this, userDetails)
     this.dataProviders = dataProviders
   }
+
+  @action
+  async requestResetToken(data) {
+    await this.request('/auth/reset', {
+      method: 'POST',
+      body: data,
+    })
+  }
 }
 
 export default User


### PR DESCRIPTION
@viktor-yakubiv Feel free to do early review. I haven't had a chance to test it but in theory, reset email will contain this link: `http://dashboard.url/reset/step2?token=<token_here>&email=<email_here>`

For dev api dashhoard url will be replaced by origin header
for prod api dashboard url will be replaced by beta.dashboard.core.ac.uk