### PR TITLE
Remove unused getDerivedStateFromProps

### DIFF
--- a/pages/_app/index.jsx
+++ b/pages/_app/index.jsx
@@ -149,18 +149,6 @@ class App extends NextApp {
     if (error instanceof UnauthorizedError) this.redirectToLogin()
   }
 
-  static getDerivedStateFromProps(props, state) {
-    const { router } = props
-    const { store } = state
-
-    if (!store) return null
-    const { dataProvider, activity } = new Route(router.asPath)
-
-    store.dataProvider = dataProvider
-    store.activity = activity
-    return null
-  }
-
   AppShell = () => {
     const { store } = this
     const { Component, pageProps } = this.props


### PR DESCRIPTION
I pushed unintentionally to master and noticed it just now. @viktor-yakubiv it was really small changes so I left it as is. Feel free to check them. This PR was supposed to contain those commits but it contains only the last piece.