### PR TITLE
Use MobX react lite over mobx-react

### DIFF
--- a/components/table/column.jsx
+++ b/components/table/column.jsx
@@ -1,7 +1,5 @@
 import React from 'react'
-import { observer } from 'mobx-react'
 
-@observer
 class Column extends React.Component {
   render() {
     const { context, getter, id } = this.props

--- a/components/table/row.jsx
+++ b/components/table/row.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { classNames } from '@oacore/design/lib/utils'
-import { observer } from 'mobx-react'
+import { observer } from 'mobx-react-lite'
 
 import styles from './styles.module.css'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11134,18 +11134,10 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.4.tgz",
       "integrity": "sha512-xRFJxSU2Im3nrGCdjSuOTFmxVDGeqOHL+TyADCGbT0k4HHqGmx5u2yaHNryvoORpI4DfbzjJ5jPmuv+d7sioFw=="
     },
-    "mobx-react": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-6.1.8.tgz",
-      "integrity": "sha512-NCMJn/hrWoeyeNbzCsBDtftWSy6VlFgw1VzhogrciPFvJIl2xs+8rJJdPlRHQTiNirwNoHNKJgUE4WhPZPvKDw==",
-      "requires": {
-        "mobx-react-lite": "^1.4.2"
-      }
-    },
     "mobx-react-lite": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
-      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-2.0.6.tgz",
+      "integrity": "sha512-h/5GqxNIoSqnjt7SHxVtU7i1Kg0Xoxj853amzmzLgLRZKK9WwPc9tMuawW79ftmFSQhML0Zwt8kEuG1DIjQNBA=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "dayjs": "^1.8.23",
     "extract-css-chunks-webpack-plugin": "^4.7.4",
     "mobx": "^5.15.4",
-    "mobx-react": "^6.1.8",
+    "mobx-react-lite": "^2.0.6",
     "mustache": "^4.0.0",
     "next": "^9.3.6",
     "next-images": "^1.4.0",

--- a/pages/data-providers/[data-provider-id]/content.jsx
+++ b/pages/data-providers/[data-provider-id]/content.jsx
@@ -3,7 +3,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
 import { classNames } from '@oacore/design/lib/utils'
-import { observer } from 'mobx-react'
+import { observer } from 'mobx-react-lite'
 
 import styles from './content.module.css'
 

--- a/store/index.jsx
+++ b/store/index.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react'
-import { useStaticRendering, observer } from 'mobx-react'
+import { useStaticRendering, observer } from 'mobx-react-lite'
 
 import RootStore from './root'
 


### PR DESCRIPTION
I am not entirely sure about this. Currently, we don't observe any class so we can change it but I don't know about the future. On the other hand, it will force us to use more hooks and decomposite as much as possible to avoid big class components.