### PR TITLE
Observer iframe after ref is assigned

### DIFF
--- a/components/forms/iframe-form.jsx
+++ b/components/forms/iframe-form.jsx
@@ -10,10 +10,12 @@ const IframeForm = ({ className, title, ...passProps }) => {
   }, [])
 
   useEffect(() => {
+    if (ref.current === null) return () => {}
+
     const observer = new ResizeObserver(resize)
     observer.observe(ref.current.contentWindow.document.body)
     return () => observer.disconnect()
-  }, [])
+  }, [ref.current])
 
   return (
     <Card className={className}>


### PR DESCRIPTION
React guarantees that ref is assigned before effect is called only when ref is direct child.