### PR TITLE
Add quotes to the copy command, fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "lint:css": "stylelint --ignore-path .gitignore '**/*.css'",
     "lint": "run-p lint:*",
     "postinstall": "run-p cp:*",
-    "cp:global": "mkdir -p ./public/design && cp -r $(npm explore @oacore/design -- pwd)/lib/global/* ./public/design"
+    "cp:global": "mkdir -p ./public/design && cp -r \"$(npm explore @oacore/design -- pwd)/lib/global/\" ./public/design"
   }
 }


### PR DESCRIPTION
If the absolute path got from npm-explore contains a space, it would be interpreted in a wrong way without quotes.