### PR TITLE
Move global CSS to a subdirectory

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "lint:css": "stylelint --ignore-path .gitignore '**/*.css'",
     "lint": "run-p lint:*",
     "postinstall": "run-p cp:*",
-    "cp:global": "mkdir -p ./public/design && cp -r \"$(npm explore @oacore/design -- pwd)/lib/global/\" ./public/design"
+    "cp:global": "mkdir -p ./public/design && cp -r \"$(npm explore @oacore/design -- pwd)/lib/global\" ./public/design"
   }
 }

--- a/public/secure/invitation.html
+++ b/public/secure/invitation.html
@@ -8,9 +8,9 @@
 <title>Register from invitation</title>
 
 <link href="/sanitize.css" rel="stylesheet" />
-<link href="/design/foundation/index.css" rel="stylesheet" />
-<link href="/design/elements/button/button.css" rel="stylesheet" />
-<link href="/design/elements/forms/text-field.css" rel="stylesheet" />
+<link href="/design/global/foundation/index.css" rel="stylesheet" />
+<link href="/design/global/elements/button/button.css" rel="stylesheet" />
+<link href="/design/global/elements/forms/text-field.css" rel="stylesheet" />
 <link href="/secure/invitation.css" rel="stylesheet" />
 
 <form id="registration-form" method="post" class="">

--- a/public/secure/login.html
+++ b/public/secure/login.html
@@ -8,9 +8,9 @@
 <title>Login into CORE Dashboard</title>
 
 <link href="/sanitize.css" rel="stylesheet" />
-<link href="/design/foundation/index.css" rel="stylesheet" />
-<link href="/design/elements/button/button.css" rel="stylesheet" />
-<link href="/design/elements/forms/text-field.css" rel="stylesheet" />
+<link href="/design/global/foundation/index.css" rel="stylesheet" />
+<link href="/design/global/elements/button/button.css" rel="stylesheet" />
+<link href="/design/global/elements/forms/text-field.css" rel="stylesheet" />
 <link href="/secure/login.css" rel="stylesheet" />
 
 <form id="login-form" method="post" class="">

--- a/public/secure/reset.html
+++ b/public/secure/reset.html
@@ -8,9 +8,9 @@
 <title>Change user password</title>
 
 <link href="/sanitize.css" rel="stylesheet" />
-<link href="/design/foundation/index.css" rel="stylesheet" />
-<link href="/design/elements/button/button.css" rel="stylesheet" />
-<link href="/design/elements/forms/text-field.css" rel="stylesheet" />
+<link href="/design/global/foundation/index.css" rel="stylesheet" />
+<link href="/design/global/elements/button/button.css" rel="stylesheet" />
+<link href="/design/global/elements/forms/text-field.css" rel="stylesheet" />
 <link href="/secure/reset.css" rel="stylesheet" />
 
 <form id="password-form" method="post" class="">


### PR DESCRIPTION
`cp` behaves differently in different systems: trailing slash in the source path can either copy contents of the directory or copy the whole directory to the target path.

More: https://stackoverflow.com/a/24925767/7205866

---

#323 did not fix but actually broke production.