### PR TITLE
Cut data overview buttons text

### DIFF
--- a/templates/overview/cards/data-statictics-card.jsx
+++ b/templates/overview/cards/data-statictics-card.jsx
@@ -62,7 +62,7 @@ const DataStatisticsCard = ({
         href="issues"
         dataProviderId={dataProviderId}
       >
-        View issues
+        Issues
       </LinkButton>
       <LinkButton
         className={styles.linkButton}
@@ -70,7 +70,7 @@ const DataStatisticsCard = ({
         href="content"
         dataProviderId={dataProviderId}
       >
-        Browse content
+        Content
       </LinkButton>
     </p>
   </OverviewCard>


### PR DESCRIPTION
A workaround to fix weird alignment when the second button drops to the next line.

@PMRuma I propose this as a temporary or even permanent fix until we find a better look for the first card (probably break it to 2 cards).