### PR TITLE
Change publication date calculation description

### DIFF
--- a/texts/depositing/chart.md
+++ b/texts/depositing/chart.md
@@ -6,8 +6,8 @@ The chart displays outputs' distribution according to deposit time lag.
 
 - **Time lag** is the difference between deposit and publication date
   in the repository.
-- **Publication date** is taken from the repository. When this is not available,
-  it is calculated from [Crossref](https://www.crossref.org).
+- **Publication date** is taken from [Crossref](https://www.crossref.org).
+  When this is not available, the repository's one used.
 - **Deposit date** is calculated using specific techniques.
   On EPrints repositories it is extracted from the *Date Deposited* field,
   while on DSpace the *dc.date.available* field is used.


### PR DESCRIPTION
We take the date from Crossref primarily now.

@mcancellieri and @nancypontika I am not sure I used correct words here. Correct me if something is wrong.