### PR TITLE
Fix deposit compliance overview card loading

### DIFF
--- a/store/deposit-dates.js
+++ b/store/deposit-dates.js
@@ -50,7 +50,7 @@ class DepositDates extends Store {
   @computed
   get complianceLevel() {
     if (this.totalCount == null || this.nonCompliantCount == null) return null
-    if (this.totalCount === 0 || this.nonCompliantCount === 0) return 0
+    if (this.totalCount === 0) return 0
     const level =
       ((this.totalCount - this.nonCompliantCount) / this.totalCount) * 100
 

--- a/templates/overview/cards/depositing-card.jsx
+++ b/templates/overview/cards/depositing-card.jsx
@@ -33,34 +33,54 @@ const getDescriptionForDepositingCard = (complianceLevel) => {
   return chartDescription
 }
 
-const DepositingCard = ({ chartData, complianceLevel, dataProviderId }) => {
-  const { title, description, action } = texts.depositing
-  const loading = chartData == null && complianceLevel == null
-  const chartDescription = getDescriptionForDepositingCard(complianceLevel)
+const filterChartData = (data, complianceLevel = 0.75) => {
+  const dataLimit = 365 * 4
+  const complianceLimit = 90
 
-  const content =
-    chartData && chartData.length > 0 ? (
-      <>
-        <TimeLagChart className={styles.chart} data={chartData} height={200} />
-        <p>{chartDescription}</p>
-        <LinkButton
-          href="deposit-compliance"
-          dataProviderId={dataProviderId}
-          className={styles.linkButton}
-        >
-          {action}
-        </LinkButton>
-      </>
-    ) : (
-      <p>{description.missingData}</p>
-    )
+  const leftLimit =
+    complianceLimit + Math.floor(dataLimit * complianceLevel) * -1
+  const rightLimit = leftLimit + dataLimit
 
-  return (
-    <OverviewCard>
-      <Card.Title tag="h2">{title}</Card.Title>
-      {loading ? <Loading /> : content}
-    </OverviewCard>
+  return data.filter(
+    (item) =>
+      item.depositTimeLag >= leftLimit && item.depositTimeLag <= rightLimit
   )
 }
+
+const Content = ({ chartData, complianceLevel, dataProviderId }) =>
+  chartData.length === 0 ? (
+    <p>{texts.depositing.description.missingData}</p>
+  ) : (
+    <>
+      <TimeLagChart
+        className={styles.chart}
+        data={filterChartData(chartData, complianceLevel / 100)}
+        height={200}
+      />
+      <p>{getDescriptionForDepositingCard(complianceLevel)}</p>
+      <LinkButton
+        href="deposit-compliance"
+        dataProviderId={dataProviderId}
+        className={styles.linkButton}
+      >
+        {texts.depositing.action}
+      </LinkButton>
+    </>
+  )
+
+const DepositingCard = ({ chartData, complianceLevel, dataProviderId }) => (
+  <OverviewCard>
+    <Card.Title tag="h2">{texts.depositing.title}</Card.Title>
+    {chartData == null || complianceLevel == null ? (
+      <Loading />
+    ) : (
+      <Content
+        complianceLevel={complianceLevel}
+        chartData={chartData}
+        dataProviderId={dataProviderId}
+      />
+    )}
+  </OverviewCard>
+)
 
 export default DepositingCard

--- a/templates/overview/index.jsx
+++ b/templates/overview/index.jsx
@@ -11,20 +11,6 @@ import {
 
 import Title from 'components/title'
 
-const filterChartData = (data, complianceLevel = 0.75) => {
-  const dataLimit = 365 * 4
-  const complianceLimit = 90
-
-  const leftLimit =
-    complianceLimit + Math.floor(dataLimit * complianceLevel) * -1
-  const rightLimit = leftLimit + dataLimit
-
-  return data.filter(
-    (item) =>
-      item.depositTimeLag >= leftLimit && item.depositTimeLag <= rightLimit
-  )
-}
-
 const OverviewTemplate = ({
   metadataCount,
   fullTextCount,
@@ -55,11 +41,7 @@ const OverviewTemplate = ({
       dataProviderId={dataProviderId}
     />
     <DepositingCard
-      chartData={
-        timeLagData &&
-        complianceLevel &&
-        filterChartData(timeLagData, complianceLevel / 100)
-      }
+      chartData={timeLagData}
       complianceLevel={complianceLevel}
       dataProviderId={dataProviderId}
     />


### PR DESCRIPTION
The loading status was detected in the wrong way. Changes it to `complianceLevel` only since it's calculated from the chart data.

Data existence calculated only from the chart size because the `complianceLevel` can be 0 when the data actually exists.

--- 

@PMRuma this should fix the problem with chart absence on the home page.