### PR TITLE
Add '202 Accepted' handling for cross-deposit-lag

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -65,13 +65,13 @@ const processStatus = (response) => {
 }
 
 const processBody = (response, { method }) => {
-  const { headers } = response
+  const { status, headers } = response
   const type = headers.get('Content-Type')
 
   return (/application\/([\w.-]\+)?json/g.test(type) && method !== 'HEAD'
     ? response.json()
     : response.blob()
-  ).then((data) => ({ data, type, headers }))
+  ).then((data) => ({ data, type, status, headers }))
 }
 
 const executeRequest = ({ url, ...options }) =>

--- a/store/deposit-dates.js
+++ b/store/deposit-dates.js
@@ -72,7 +72,13 @@ class DepositDates extends Store {
 
   @action
   async retrieveCrossDepositLag() {
-    const { data } = await this.request(this.crossDepositLagUrL)
+    const response = await this.request(this.crossDepositLagUrL)
+
+    // Use data only if status is 200 OK
+    // Ignore body if got 202 Accepted
+    const { status } = response
+    const data = status === 200 || status === 0 ? response.data : {}
+
     this.crossDepositLag = data
   }
 


### PR DESCRIPTION
@Joozty this does not communicate to the user at all. I hope it will keep _Loading..._ forever because of `undefined` (nullish) values inside `crossDepositLag` property. Although, infinite loading seems to be fine to me at the moment.

I do not need more than this at this point for #335 but feel free to properly solve the bug.

At the moment I see 2 options:

1. Add status processing to `Root.defaultOptions.request` and if it's 202, return another promise that waits some time and repeats the request. It will keep the infinite loading and will not communicate the state properly but gives a hope that the request finishes sometime.

2. Throw 202 as some kind 'AwaitingError' and check it in place and communicate to the user. Also, applying the modified first option is possible.