### PR TITLE
Show correct message when invitation cannot be send

### DIFF
--- a/store/organisation.js
+++ b/store/organisation.js
@@ -16,7 +16,7 @@ class Organisation extends Store {
       if (error instanceof NotAcceptableError)
         return { message: 'Email for this organisation is already registered.' }
 
-      return { message: 'Something went wrong. Please try it later.' }
+      return { message: 'Something went wrong. Please try again later.' }
     }
 
     return { message: 'Invitation has been sent.' }

--- a/store/organisation.js
+++ b/store/organisation.js
@@ -15,6 +15,8 @@ class Organisation extends Store {
     } catch (error) {
       if (error instanceof NotAcceptableError)
         return { message: 'Email for this organisation is already registered.' }
+
+      return { message: 'Something went wrong. Please try it later.' }
     }
 
     return { message: 'Invitation has been sent.' }


### PR DESCRIPTION
@viktor-yakubiv The reason why I couldn't get an email is that there is a continuing CORS issue. 😢 Obviously this PR doesn't fix it. It just makes UI show correct message.