### PR TITLE
Add table config updates

### DIFF
--- a/components/table/table.jsx
+++ b/components/table/table.jsx
@@ -51,9 +51,7 @@ class InfiniteTable extends React.PureComponent {
       selectedOption: null,
     }
 
-    this.action = action
-    this.sidebar = sidebar
-    this.columns = columns
+    Object.assign(this, { action, sidebar, columns })
   }
 
   componentDidMount() {
@@ -62,6 +60,11 @@ class InfiniteTable extends React.PureComponent {
       'sidebar-close',
       this.closeSidebar
     )
+  }
+
+  componentDidUpdate() {
+    const { action, sidebar, columns } = this.getConfig()
+    Object.assign(this, { action, sidebar, columns })
   }
 
   componentWillUnmount() {

--- a/templates/deposit-compliance/cards/table-card.jsx
+++ b/templates/deposit-compliance/cards/table-card.jsx
@@ -126,9 +126,11 @@ const DepositDatesTable = ({
         className={styles.depositDateColumn}
         getter={(v) => formatDate(v.publicReleaseDate)}
       />
-      <Table.Sidebar>
-        <SidebarContent />
-      </Table.Sidebar>
+      {!hasError && (
+        <Table.Sidebar>
+          <SidebarContent />
+        </Table.Sidebar>
+      )}
       <Table.Action>
         <ExportButton href={datesUrl} disabled={isExportDisabled}>
           {texts.exporting.download}


### PR DESCRIPTION
Add simultaneous updates of action, sidebar and columns with props.

Fixes the bug with empty sidebar if there is any `pages.error`. @Joozty I wonder why it happens, by the way?