### PR TITLE
Fix paginated requests processing

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -54,8 +54,8 @@ const prepareRequest = (init) => {
 
 const processStatus = (response) => {
   if (response.status >= 400) {
-    const Error = NetworkError.getErrorFromStatusCode(response.status)
-    throw new Error(
+    const StatusError = NetworkError.getErrorFromStatusCode(response.status)
+    throw new StatusError(
       `Request for ${response.url} failed on ${response.status}`,
       response
     )
@@ -76,8 +76,12 @@ const processBody = (response, { method }) => {
 
 const processError = (error, details) => {
   const { response } = error
+  if (response == null) throw error // re-throwing if nothing to process
+
   return processBody(response, details).then((body) => {
     Object.assign(error, body)
+
+    // re-throwing after processing
     throw error
   })
 }

--- a/store/helpers/pages/pages.js
+++ b/store/helpers/pages/pages.js
@@ -82,18 +82,19 @@ class Pages extends Store {
           resolve(transformedData)
         })
         .catch((error) => {
-          // Storing the error to propagate messages to the UI
-          this.error = error
-          this.data = error.data
-
           // Resetting pointers to prevent pagination working
           this.isFirstPageLoaded = true
           this.isLastPageLoaded = true
 
-          if (error instanceof NotFoundError) {
-            this.data = []
-            resolve()
-          } else if (error instanceof PaymentRequiredError) {
+          // We use NotFoundError to detect the end of the data stream
+          // If it happens we avoid any error processing
+          if (error instanceof NotFoundError) return resolve()
+
+          // Storing the error to propagate messages to the UI
+          this.error = error
+          this.data = error.data
+
+          if (error instanceof PaymentRequiredError) {
             // Stripping data to 5 elements only if there are more
             // These elements may be used as a preview
             this.data = this.data.slice(0, 5)
@@ -103,8 +104,10 @@ class Pages extends Store {
             // no data instead
             if (this.data.length === 0) this.error = null
 
-            resolve()
-          } else reject(error)
+            return resolve()
+          }
+
+          return reject(error)
         })
     )
   }


### PR DESCRIPTION
We use `NotFoundError` to detect the end of the data stream. If it happens we avoid any error processing.

I did not know that so it caused the bug with Issues when there is the only page to display.

This is an inter-release bug fix.