### PR TITLE
Fix export enabled/disabled for DOIs

### DIFF
--- a/pages/data-providers/[data-provider-id]/doi.jsx
+++ b/pages/data-providers/[data-provider-id]/doi.jsx
@@ -7,7 +7,11 @@ const DoiPage = ({ store, ...props }) => (
   <DoiTemplate
     enrichmentSize={store.doi.enrichmentSize}
     doiUrl={store.doi.doiUrl}
-    isExportDisabled={store.doi.isExportDisabled}
+    isExportDisabled={
+      store.doi.enrichmentSize === 0 ||
+      store.doi.doiRecords.error != null ||
+      store.doi.doiRecords.data.length === 0
+    }
     doiCount={store.doi.originCount}
     dataProviderName={store.dataProvider.name}
     doiRecords={store.doi.doiRecords}

--- a/store/doi.js
+++ b/store/doi.js
@@ -27,11 +27,6 @@ class DOI extends Store {
     return lag
   }
 
-  @computed
-  get isExportDisabled() {
-    return this.enrichmentSize <= 0
-  }
-
   @observable doiRecords = null
 
   constructor(baseUrl, options) {

--- a/templates/doi/index.jsx
+++ b/templates/doi/index.jsx
@@ -27,11 +27,7 @@ const DoiTemplate = ({
     <ExportCard
       enrichmentSize={enrichmentSize}
       doiUrl={doiUrl}
-      isExportDisabled={
-        isExportDisabled ||
-        doiRecords.error != null ||
-        doiRecords.data.length === 0
-      }
+      isExportDisabled={isExportDisabled}
     />
     <TableCard pages={doiRecords} />
   </Tag>


### PR DESCRIPTION
Removes `isExportDisabled` from the DOI store.

Moves all calculations to the `pages/doi.jsx`.

---

@Joozty this behaves weird. MobX-observer does not track calls store properties in the child components. The only reason for this could be that React renders it asynchronously so MobX tracks only a property (e.g. `anObservable.a`) accessed but not nested properties if there was any (e.g. `anObservable.a.b`) so any changes to nested properties will not rerender the component.

This caused the bug with the export button not becoming enabled when `Pages.data.length` changes.