### PR TITLE
Restore sidebar size back to 12rem

### DIFF
--- a/components/layout/styles.module.css
+++ b/components/layout/styles.module.css
@@ -2,7 +2,7 @@
 @custom-media --screen-until-desktop (max-width: 727px);
 
 .container {
-  --side-bar-width: 13rem;
+  --side-bar-width: 12rem;
   --app-bar-skip: 3.5rem;
 
   display: flex;


### PR DESCRIPTION
It's not needed since we renamed 'Deposit compliance' tab