### PR TITLE
Polyfill ResizeObserver

### DIFF
--- a/components/forms/iframe-form.jsx
+++ b/components/forms/iframe-form.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useCallback, useRef } from 'react'
+import ResizeObserver from 'resize-observer-polyfill'
 
 import styles from './styles.module.css'
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "recharts": "^1.8.5",
     "remark-heading-id": "^1.0.0",
     "remark-slug": "^6.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "source-map-loader": "^0.2.4",
     "webpack": "^4.43.0"
   },


### PR DESCRIPTION
Apparently [ResizeObserver is not present in Edge ](https://caniuse.com/#feat=resizeobserver)<=18.x.x hence this polyfill.