### PR TITLE
Don't show logout message when /user endpoint is just checked for status

### DIFF
--- a/pages/_app/index.jsx
+++ b/pages/_app/index.jsx
@@ -118,7 +118,9 @@ class App extends NextApp {
       .catch((error) => {
         if (error instanceof AuthorizationError) {
           this.setState({ isAuthorized: false })
-          this.redirectToLogin()
+          this.redirectToLogin({
+            reason: '',
+          })
         } else throw error
       })
   }


### PR DESCRIPTION
IMHO this message may confuse the user. There is a use case that for example user never logged in and they see this message which is wrong. 