### PR TITLE
Use /user/data-providers endpoint

### DIFF
--- a/store/resource.js
+++ b/store/resource.js
@@ -57,7 +57,7 @@ class Resource {
         )
       }
 
-      return request(this[scopeUrl]).then((data) => {
+      return request(this[scopeUrl]).then(({ data }) => {
         this.extend({ [scope]: data })
         return data
       })

--- a/store/user/dashboard.js
+++ b/store/user/dashboard.js
@@ -4,6 +4,11 @@ class DashboardUser extends User {
   static defaultValues = {
     ...User.defaultValues,
     dataProviders: [],
+    dataProvider: null,
+  }
+
+  retrieve(...scopes) {
+    return super.retrieve('dataProviders', ...scopes)
   }
 
   canManage(dataProviderId) {

--- a/store/user/dashboard.js
+++ b/store/user/dashboard.js
@@ -15,6 +15,10 @@ class DashboardUser extends User {
     return this.dataProviders.some(({ id }) => dataProviderId === id)
   }
 
+  getDataProviderById(dataProviderId) {
+    return this.dataProviders.find(({ id }) => dataProviderId === id)
+  }
+
   searchDataProviders(searchTerm) {
     return this.dataProviders.filter(
       (e) => e.name.toLowerCase().search(searchTerm.toLowerCase()) !== -1

--- a/templates/overview/cards/rioxx-card.jsx
+++ b/templates/overview/cards/rioxx-card.jsx
@@ -48,14 +48,13 @@ const Content = ({ compliantCount, totalCount, missingTerms }) => (
       title={`${formatNumber(compliantCount)} out of ${formatNumber(
         totalCount
       )} outputs are compliant with basic RIOXX`}
-      tag="p"
     >
       compliant with RIOXX
     </PercentageChart>
     <ul className={styles.issuesList}>
       {missingTerms.map(({ elementName, outputsCount }) => (
-        <li>
-          <span className={styles.count}>{formatNumber(outputsCount)}</span>
+        <li key={elementName}>
+          <span>{formatNumber(outputsCount)}</span>
           &nbsp;outputs are missing&nbsp;
           <code>{elementName}</code>
         </li>


### PR DESCRIPTION
I hope I haven't missed anything. It's affecting the whole dashboard. So we should probably wait a little but and create a separate release. The biggest change is that data providers are now a full part of a user entity and changes on [the root store are reflected through the callback](https://github.com/oacore/dashboard/blob/data-providers/store/root.js#L109).