### PR TITLE
Fix dataprovider

### DIFF
--- a/store/root.js
+++ b/store/root.js
@@ -110,7 +110,7 @@ class Root extends Store {
   set dataProvider(dataProvider) {
     // Check access rights
     if (dataProvider !== null && !this.user.canManage(dataProvider?.id)) {
-      const dpStr = `DataProvider#${dataProvider.id}`
+      const dpStr = `DataProvider#${dataProvider?.id}`
       throw new AccessError(`${this.user} does not have access to the ${dpStr}`)
     }
 

--- a/store/root.js
+++ b/store/root.js
@@ -122,7 +122,7 @@ class Root extends Store {
     return this.user.dataProviders
   }
 
-  @action async init(dataProviderId) {
+  @action async init() {
     try {
       await this.user.retrieve()
     } catch (unauthorizedError) {
@@ -131,8 +131,6 @@ class Root extends Store {
     }
     this.organisation = new Organisation(this.user.affiliationUrl, this.options)
     this.organisation.retrieve()
-
-    this.changeDataProvider(dataProviderId)
   }
 
   @action changeDataProvider(id) {


### PR DESCRIPTION
Apparently some people try to access data providers not assigned to them. First commit fixes the issue 
`Cannot read property 'id' of undefined` but it's not a really fix for the issue itself. 

In the second commit I tried to cover case when user access data provider which is not managed by them. If it happens user is redirected to `/data-providers` which redirect them to the fist available data provider. It's probably better than blank screen.  I am not entirely sure about the second commit. I had to do some changes I sort of don't  like but there was no other option I could think of.



Based on https://sentry.io/organizations/oacore/issues/1781836363/?project=2091955&query=is%3Aunresolved

