### PR TITLE
Hide Rioxx card if we don't have a data for it

### DIFF
--- a/templates/overview/index.jsx
+++ b/templates/overview/index.jsx
@@ -51,7 +51,9 @@ const OverviewTemplate = ({
       enrichmentSize={doiEnrichmentSize}
       dataProviderId={dataProviderId}
     />
-    {rioxxCompliance != null && <RioxxCard compliance={rioxxCompliance} />}
+    {rioxxCompliance != null && rioxxCompliance.totalCount > 0 && (
+      <RioxxCard compliance={rioxxCompliance} />
+    )}
     {viewStatistics != null && <IrusCard statistics={viewStatistics} />}
   </Tag>
 )


### PR DESCRIPTION
I decided to hide Rioxx card if we don't have a data for it because the percentage chart doesn't render correctly. Other possibility was to show error message in the but hiding seems to be more appropriate.


Test here
http://dashboard.core.ac.uk/data-providers/128/overview