### PR TITLE
Fix resources are loaded twice for superadmin

### DIFF
--- a/store/resource.js
+++ b/store/resource.js
@@ -10,6 +10,10 @@ class Resource {
 
   static defaultValues = {}
 
+  get retrieved() {
+    return !!this.id
+  }
+
   constructor(init, options) {
     this.options = { ...this.constructor.defaultOptions, ...options }
 
@@ -41,11 +45,11 @@ class Resource {
 
   retrieve(...scopes) {
     const { request } = this.options
-    if (!this.id) {
+    if (!this.retrieved) {
       return request(this.url).then(
         ({ data }) => {
           this.extend(data)
-          return this.retrieve(...scopes)
+          return Resource.prototype.retrieve.apply(this, scopes)
         },
         (error) => {
           throw error


### PR DESCRIPTION
I noticed it now. Sorry I didn't include it in the previous PR. Anyway, I don't feel like this is a solution to the problem. I am not sure if it is possible to access the retrieve method from Resource instead of the one from DataProvider.


You can observe the problem when you access the repository as a superadmin. Try to open network tab and you will see resources are loaded twice.

http://core.dashboard:3000/data-providers/169/deposit-compliance