### PR TITLE
Move ResizeObserver to iframes

### DIFF
--- a/components/forms/change-password/index.jsx
+++ b/components/forms/change-password/index.jsx
@@ -22,6 +22,7 @@ const ChangePassword = ({ className, email, token, tag }) => {
         {email ? 'Change password' : 'Reset password'}
       </Card.Title>
       <IframeForm
+        id="reset-password-form"
         className={styles.changePasswordIframe}
         title="Password change form"
         src={`/secure/reset.html?${search}`}

--- a/components/forms/iframe-form.jsx
+++ b/components/forms/iframe-form.jsx
@@ -1,42 +1,29 @@
-import React, { useEffect, useCallback, useRef } from 'react'
-import ResizeObserver from 'resize-observer-polyfill'
+import React, { useMemo } from 'react'
 
 import styles from './styles.module.css'
 
 import { Card } from 'design'
 
-const IframeForm = ({ className, title, ...passProps }) => {
-  const ref = useRef(null)
+const IframeForm = ({ id, className, title, src, ...passProps }) => {
+  const iframeSrc = useMemo(() => {
+    const unknownOrigin = 'https://unknown.origin'
+    const url = new URL(src, unknownOrigin)
+    const params = new URLSearchParams(url.searchParams)
+    params.set('elementId', id)
 
-  const resize = useCallback(() => {
-    ref.current.style.height = `${ref.current.contentWindow.document.body.offsetHeight}px`
-  }, [])
+    if (url.origin === unknownOrigin)
+      return `${url.pathname}?${params.toString()}`
 
-  const observer = useRef(new ResizeObserver(resize))
-
-  const handleOnLoad = useCallback(() => {
-    if (ref.current.contentWindow.document.body) {
-      observer.current.unobserve(ref.current.contentWindow.document.body)
-      observer.current.observe(ref.current.contentWindow.document.body)
-      resize()
-    }
-  }, [])
-
-  useEffect(() => {
-    // onLoad event may be fired before the JS is completely loaded
-    // ensure the element gets observed
-    // https://github.com/facebook/react/issues/15446
-    handleOnLoad()
-    return () => observer.current.disconnect()
-  }, [])
+    return `${url.href}?${params.toString()}`
+  }, [src, id])
 
   return (
     <Card className={className}>
       <iframe
-        ref={ref}
+        id={id}
         className={styles.iframeForm}
         title={title}
-        onLoad={handleOnLoad}
+        src={iframeSrc}
         {...passProps}
       />
     </Card>

--- a/components/forms/invitation-register/index.jsx
+++ b/components/forms/invitation-register/index.jsx
@@ -20,8 +20,9 @@ const InvitationRegister = ({ className, email, invitationCode, tag }) => {
     <Card className={className} tag={tag}>
       <h2>Register</h2>
       <IframeForm
+        id="invitation-form"
         className={styles.invitationRegisterIframe}
-        title="Password change form"
+        title="Registration form"
         src={`/secure/invitation.html?${search}`}
       />
     </Card>

--- a/components/forms/styles.module.css
+++ b/components/forms/styles.module.css
@@ -1,3 +1,6 @@
 .iframe-form {
   width: 100%;
+
+  /* Some arbitrary height in case browser doesn't support ResizeObserver */
+  min-height: 15rem;
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "recharts": "^1.8.5",
     "remark-heading-id": "^1.0.0",
     "remark-slug": "^6.0.0",
-    "resize-observer-polyfill": "^1.5.1",
     "webpack": "^4.44.2"
   },
   "engines": {

--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -40,6 +40,7 @@ const Login = React.memo(() => {
     <>
       <Title hidden>Login</Title>
       <IframeForm
+        id="login-form"
         className={styles.loginIframeContainer}
         title="Login Form"
         src={url}

--- a/public/secure/invitation.html
+++ b/public/secure/invitation.html
@@ -38,4 +38,5 @@
   <button class="button contained" type="submit">Register</button>
 </form>
 
+<script src="/secure/resize.js" ></script>
 <script src="/secure/invitation.js" ></script>

--- a/public/secure/login.html
+++ b/public/secure/login.html
@@ -41,4 +41,6 @@
   <a class="forgotten-password" href="/reset" target="_top">Forgotten password?</a>
 </form>
 
+
+<script src="/secure/resize.js" ></script>
 <script src="/secure/login.js" ></script>

--- a/public/secure/reset.html
+++ b/public/secure/reset.html
@@ -43,4 +43,5 @@
   <button class="button contained" type="submit">Save</button>
 </form>
 
+<script src="/secure/resize.js" ></script>
 <script src="/secure/reset.js" ></script>

--- a/public/secure/resize.js
+++ b/public/secure/resize.js
@@ -1,0 +1,29 @@
+function handleResizeEvent(entries, elementId) {
+  // https://stackoverflow.com/a/58701523/5594539
+  window.requestAnimationFrame(() => {
+    if (!Array.isArray(entries) || !entries.length) return
+
+    const iframe = window.parent.document.getElementById(elementId)
+    iframe.style.height = `${window.document.body.offsetHeight}px`
+  })
+}
+
+// https://stackoverflow.com/a/326076/5594539
+function isInIframe() {
+  try {
+    return window.self !== window.top
+  } catch (e) {
+    return true
+  }
+}
+
+const url = new URL(window.location)
+if (
+  isInIframe() &&
+  typeof window.ResizeObserver !== 'undefined' &&
+  url.searchParams.has('elementId')
+) {
+  new ResizeObserver((entries) =>
+    handleResizeEvent(entries, url.searchParams.get('elementId'))
+  ).observe(document.body)
+}

--- a/utils/sentry.js
+++ b/utils/sentry.js
@@ -6,6 +6,7 @@ let sentryOptions
 if (process.env.SENTRY_DSN) {
   sentryOptions = {
     dsn: process.env.SENTRY_DSN,
+    ignoreErrors: ['ResizeObserver loop limit exceeded'],
   }
 }
 


### PR DESCRIPTION
I slightly refactored to implementation. The workflow is following:

1. Load iframe with `elementId` parameter
2. If that parameter exists and the page is loaded from within the iframe and ResizeObserver API exist
     - Listen on any resize change and update height on `elementId` element from parent
3. Else the arbitrary height is applied and user sees scrollbar (hope it never happens)
